### PR TITLE
tools: In the ndnrepowatch usage message, fix command [-s].

### DIFF
--- a/tools/ndnrepowatch.cpp
+++ b/tools/ndnrepowatch.cpp
@@ -295,7 +295,7 @@ usage()
   fprintf(stderr,
           "NdnRepoWatch [-I identity]"
           "  [-x freshness] [-l lifetime] [-w watchtimeout]"
-          "  [-n maxinterestnum][-s stop] [-c check]repo-prefix ndn-name\n"
+          "  [-n maxinterestnum][-s] [-c check]repo-prefix ndn-name\n"
           "\n"
           " Write a file into a repo.\n"
           "  -I: specify identity used for signing commands\n"


### PR DESCRIPTION
The ndnrepowatch usage message said [-s stop] but the command is simply [-s].
